### PR TITLE
Migrate from ec2 to ec2_instance module of aws collection

### DIFF
--- a/create_base_ami.yml
+++ b/create_base_ami.yml
@@ -18,6 +18,7 @@
         instance_tags: {"Name": "amibuilder_base"},
         instance_type: "t3.nano",
         count: 1,
+        count_filters: {"tag:Name": "amibuilder_base"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetCId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"

--- a/create_web_app_ami.yml
+++ b/create_web_app_ami.yml
@@ -18,6 +18,7 @@
         instance_tags: {"Name": "amibuilder_web_app"},
         instance_type: "t3.nano",
         count: 1,
+        count_filters: {"tag:Name": "amibuilder_web_app"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetBId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"

--- a/create_web_base_ami.yml
+++ b/create_web_base_ami.yml
@@ -18,6 +18,7 @@
         instance_tags: {"Name": "amibuilder_web_base"},
         instance_type: "t3.nano",
         count: 1,
+        count_filters: {"tag:Name": "amibuilder_web_base"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetBId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"

--- a/roles/aws-ec2-terminate/tasks/main.yml
+++ b/roles/aws-ec2-terminate/tasks/main.yml
@@ -14,7 +14,7 @@
   register: ec2_instances
 
 - name: Terminate instance
-  amazon.aws.ec2:
+  amazon.aws.ec2_instance:
     state: 'absent'
     instance_ids: "{{ item.instance_id }}"
     region: "{{ aws_ec2_terminate_region }}"

--- a/roles/aws-ec2/tasks/main.yml
+++ b/roles/aws-ec2/tasks/main.yml
@@ -3,9 +3,10 @@
 # Launches EC2 instance with specified AMI, or makes sure it exists
 # Inputs:
 # - ami_id
-# - instance_tags: A hash dictionary of instance tags
+# - instance_tags: A dictionary of tags to attach to the EC2 instance(s)
 # - instance_type
-# - count
+# - count: Number of EC2 instance(s)
+# - count_filters: A dictionary of filters to use for counting
 # - vpc_subnet_id
 # - security_group_id
 # - region
@@ -13,18 +14,19 @@
 # - ec2
 
 - name: Launch instance
-  amazon.aws.ec2:
+  amazon.aws.ec2_instance:
     key_name: default
-    instance_tags: "{{ instance_tags }}"
     instance_type: "{{ instance_type }}"
-    image: "{{ ami_id }}"
+    image_id: "{{ ami_id }}"
     wait: yes
     exact_count: "{{ count }}"
-    count_tag: "{{ instance_tags }}"
-    assign_public_ip: yes
+    filters: "{{ count_filters }}"
     vpc_subnet_id: "{{ vpc_subnet_id }}"
-    group_id: "{{ security_group_id }}"
+    security_group: "{{ security_group_id }}"
     region: "{{ region }}"
+    network:
+      assign_public_ip: yes
+    tags: "{{ instance_tags }}"
   register: ec2
 
 - name: Wait for SSH to come up


### PR DESCRIPTION
## Description

Per ansible aws collection [ec2 module docs](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_module.html#deprecated) the `ec2` module is deprecated and removed altogether in version 4.0.0 because it is based on a deprecated version of the AWS SDK.

This migrates playbooks to using the newer [ec2_instance](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_instance_module.html) module.