### PR TITLE
Use public IP address only for connecting to EC2 host

### DIFF
--- a/ansible_plugins/production_aws_ec2.yml
+++ b/ansible_plugins/production_aws_ec2.yml
@@ -49,9 +49,9 @@ hostnames:
 # a list in order of precedence for hostname variables.
 # 
   - ip-address
-  - dns-name
-  - tag:Name
-  - private-ip-address
+#  - dns-name
+#  - tag:Name
+#  - private-ip-address
 
 compose:
 # use if you need to connect via the ec2
@@ -62,3 +62,4 @@ compose:
 # instances don't use a public ip address
 #
 #  ansible_host: private_ip_address
+#  ansible_host: public_ip_address


### PR DESCRIPTION
## Description

With either ansible or its AWS collection update it started to attempt connecting to the same host multiple times, using all of public IP, tag name, and private IP. The latter 2 would fail. This fix makes it only connect by public IP.