### PR TITLE
Scale up from t3.nano to t3.small

### DIFF
--- a/deploy_web_app_ami.yml
+++ b/deploy_web_app_ami.yml
@@ -18,7 +18,7 @@
         web_app_alb_subnet_ids: "{{ [aws_vpc_output.stack_outputs.PublicSubnetAId, aws_vpc_output.stack_outputs.PublicSubnetBId, aws_vpc_output.stack_outputs.PublicSubnetCId, aws_vpc_output.stack_outputs.PublicSubnetDId, aws_vpc_output.stack_outputs.PublicSubnetEId] | join(',') }}",
         web_app_ami_id: "{{ aws_ami_lookup_ami.image_id }}",
         web_app_asg_cpu_scaling_threshold: 50,
-        web_app_instance_type: "t3.nano",
+        web_app_instance_type: "t3.small",
         web_app_instances_desired: 1,
         web_app_instances_max: 3,
         web_app_instances_min: 1,


### PR DESCRIPTION
## Description

The `t3.small` gives a significantly more consistent performance over `t3.nano`.