### PR TITLE
Add support for IPv6

### DIFF
--- a/roles/aws-route53/files/cloudformation-web-domain.yml
+++ b/roles/aws-route53/files/cloudformation-web-domain.yml
@@ -22,6 +22,12 @@ Resources:
             EvaluateTargetHealth: true
             HostedZoneId: !ImportValue WebLoadBalancerHostedZoneIdUsEast1
           Type: A
+        - Name: !Ref Domain
+          AliasTarget:
+            DNSName: !ImportValue WebLoadBalancerDnsNameUsEast1
+            EvaluateTargetHealth: true
+            HostedZoneId: !ImportValue WebLoadBalancerHostedZoneIdUsEast1
+          Type: AAAA
 
   WebMailRecordSetGroup:
     Type: AWS::Route53::RecordSetGroup

--- a/roles/aws-vpc/files/cloudformation-us-east-1-sg.yml
+++ b/roles/aws-vpc/files/cloudformation-us-east-1-sg.yml
@@ -16,6 +16,15 @@ Resources:
       ToPort: 22
       CidrIp: 0.0.0.0/0
 
+  BastionSecurityGroupIngressIPv6:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref BastionSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: "::/0"
+
   WebAppLoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -30,6 +39,14 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIpv6: "::/0"
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIpv6: "::/0"
       VpcId: !ImportValue VpcIdUsEast1
 
   WebAppServerSecurityGroup:

--- a/roles/aws-vpc/files/cloudformation-us-east-1-vpc.yml
+++ b/roles/aws-vpc/files/cloudformation-us-east-1-vpc.yml
@@ -5,42 +5,63 @@ Resources:
     Properties:
       CidrBlock: 10.100.0.0/16
 
+  IPv6CidrBlock:
+    Type: AWS::EC2::VPCCidrBlock
+    Properties:
+      AmazonProvidedIpv6CidrBlock: true
+      VpcId: !Ref MainVpc
+
   PublicSubnetA:
     Type: AWS::EC2::Subnet
+    DependsOn: IPv6CidrBlock
     Properties:
+      AssignIpv6AddressOnCreation: true
       CidrBlock: 10.100.0.0/24
+      Ipv6CidrBlock: !Select [ 0, !Cidr [ !Select [ 0, !GetAtt MainVpc.Ipv6CidrBlocks], 256, 64 ]]
       AvailabilityZone: us-east-1a
       VpcId: !Ref MainVpc
       MapPublicIpOnLaunch: true
 
   PublicSubnetB:
     Type: AWS::EC2::Subnet
+    DependsOn: IPv6CidrBlock
     Properties:
+      AssignIpv6AddressOnCreation: true
       CidrBlock: 10.100.1.0/24
+      Ipv6CidrBlock: !Select [ 1, !Cidr [ !Select [ 0, !GetAtt MainVpc.Ipv6CidrBlocks], 256, 64 ]]
       AvailabilityZone: us-east-1b
       VpcId: !Ref MainVpc
       MapPublicIpOnLaunch: true
 
   PublicSubnetC:
     Type: AWS::EC2::Subnet
+    DependsOn: IPv6CidrBlock
     Properties:
+      AssignIpv6AddressOnCreation: true
       CidrBlock: 10.100.2.0/24
+      Ipv6CidrBlock: !Select [ 2, !Cidr [ !Select [ 0, !GetAtt MainVpc.Ipv6CidrBlocks], 256, 64 ]]
       AvailabilityZone: us-east-1c
       VpcId: !Ref MainVpc
       MapPublicIpOnLaunch: true
 
   PublicSubnetD:
     Type: AWS::EC2::Subnet
+    DependsOn: IPv6CidrBlock
     Properties:
+      AssignIpv6AddressOnCreation: true
       CidrBlock: 10.100.3.0/24
+      Ipv6CidrBlock: !Select [ 3, !Cidr [ !Select [ 0, !GetAtt MainVpc.Ipv6CidrBlocks], 256, 64 ]]
       AvailabilityZone: us-east-1d
       VpcId: !Ref MainVpc
       MapPublicIpOnLaunch: true
 
   PublicSubnetE:
     Type: AWS::EC2::Subnet
+    DependsOn: IPv6CidrBlock
     Properties:
+      AssignIpv6AddressOnCreation: true
       CidrBlock: 10.100.4.0/24
+      Ipv6CidrBlock: !Select [ 4, !Cidr [ !Select [ 0, !GetAtt MainVpc.Ipv6CidrBlocks], 256, 64 ]]
       AvailabilityZone: us-east-1e
       VpcId: !Ref MainVpc
       MapPublicIpOnLaunch: true
@@ -64,6 +85,13 @@ Resources:
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicDefaultRouteIPv6:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationIpv6CidrBlock: "::/0"
       GatewayId: !Ref InternetGateway
 
   PublicSubnetARouteTableAssociation:

--- a/roles/web-app/files/cloudformation-us-east-1-app.yml
+++ b/roles/web-app/files/cloudformation-us-east-1-app.yml
@@ -108,7 +108,7 @@ Resources:
   WebApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      IpAddressType: ipv4
+      IpAddressType: dualstack
       Scheme: internet-facing
       SecurityGroups: !Ref AlbSecurityGroupIds
       Subnets: !Ref AlbSubnetIds


### PR DESCRIPTION
## Description

In order to serve traffic over IPv6 AWS requires that the entire stack has IPv6 enabled - including affected VPC, subnets and security groups. This adds support for IPv6 everywhere and enables DNS and load balancer to handle IPv6 traffic.