### PR TITLE
Fix new ansible ec2 AMI creation errors

### DIFF
--- a/create_base_ami.yml
+++ b/create_base_ami.yml
@@ -18,17 +18,11 @@
         instance_tags: {"Name": "amibuilder_base"},
         instance_type: "t3.nano",
         count: 1,
-        count_filters: {"tag:Name": "amibuilder_base"},
+        count_filters: {"tag:Name": "amibuilder_base", "instance-state-name": "running"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetCId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"
       }
-
-- hosts: localhost
-  gather_facts: no
-  tasks:
-    - name: Refresh inventory
-      meta: refresh_inventory
 
 - hosts: tag_Name_amibuilder_base
   roles:

--- a/create_web_app_ami.yml
+++ b/create_web_app_ami.yml
@@ -18,17 +18,11 @@
         instance_tags: {"Name": "amibuilder_web_app"},
         instance_type: "t3.nano",
         count: 1,
-        count_filters: {"tag:Name": "amibuilder_web_app"},
+        count_filters: {"tag:Name": "amibuilder_web_app", "instance-state-name": "running"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetBId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"
       }
-
-- hosts: localhost
-  gather_facts: no
-  tasks:
-    - name: Refresh inventory
-      meta: refresh_inventory
 
 - hosts: tag_Name_amibuilder_web_app
   roles:

--- a/create_web_base_ami.yml
+++ b/create_web_base_ami.yml
@@ -18,17 +18,11 @@
         instance_tags: {"Name": "amibuilder_web_base"},
         instance_type: "t3.nano",
         count: 1,
-        count_filters: {"tag:Name": "amibuilder_web_base"},
+        count_filters: {"tag:Name": "amibuilder_web_base", "instance-state-name": "running"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetBId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"
       }
-
-- hosts: localhost
-  gather_facts: no
-  tasks:
-    - name: Refresh inventory
-      meta: refresh_inventory
 
 - hosts: tag_Name_amibuilder_web_base
   roles:

--- a/provision_bastion.yml
+++ b/provision_bastion.yml
@@ -22,11 +22,6 @@
         region: "{{ aws_region }}"
       }
 
-- hosts: localhost
-  tasks:
-    - name: Refresh inventory
-      meta: refresh_inventory
-
 - hosts: tag_Name_bastion
   roles:
     - bastion

--- a/roles/aws-ec2/tasks/main.yml
+++ b/roles/aws-ec2/tasks/main.yml
@@ -30,8 +30,9 @@
   register: ec2
 
 - name: Wait for SSH to come up
-  delegate_to: "{{ item.public_dns_name }}"
+  delegate_to: "{{ item.public_ip_address }}"
   wait_for_connection:
-    delay: 60
+    delay: 30
+    sleep: 5
     timeout: 320
   loop: "{{ ec2.instances }}"

--- a/roles/aws-ec2/tasks/main.yml
+++ b/roles/aws-ec2/tasks/main.yml
@@ -29,6 +29,9 @@
     tags: "{{ instance_tags }}"
   register: ec2
 
+- name: Refresh inventory
+  meta: refresh_inventory
+
 - name: Wait for SSH to come up
   delegate_to: "{{ item.public_ip_address }}"
   wait_for_connection:


### PR DESCRIPTION
## Description

These issues were caused either by ansible upgrade and/or change in the AWS service. Fixed:

* Move the `refresh_inventory` step in the `aws-ec2` role, as it was also needed for SSH connection checks by `wait_for_connection`.
* Replace `public_dns_name` with `public_ip_address` because the former is now empty.
* Add instance state filter to ensure it's in a running state, and not, for example, terminated.
* Reduce the `delay` in `wait_for_connection` from 1 min to 30 secs - AWS instances seem to boot up pretty quickly