### PR TITLE
Upgrade all AMIs to Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Load Balancer and Autoscaling Group](#load-balancer-and-autoscaling-group)
   - [Deployments](#deployments)
     - [Create and Deploy a New Web App AMI](#create-and-deploy-a-new-web-app-ami)
+  - [SSH to Bastion and beyond](#ssh-to-bastion-and-beyond)
 
 ## Base setup
 
@@ -79,8 +80,11 @@ ansible-playbook -e "aws_region=us-east-1" -e "web_app_release_version=0.0.1" cr
 This command will expect the OTP release archive to be available at the following location
 
 ```
-https://github.com/RinseOne/rinseweb/releases/download/0.0.1/rinseweb.tar.gz
+https://github.com/RinseOne/rinseweb/releases/download/0.0.1/rinseweb-ubuntu-22.04-amd64.tar.gz
 ```
+
+Optionally, when `-e "pause_after_instance_ready=true"` flag is specified, the playbook will pause after the web app
+candidate instance is ready, before taking its AMI and shutting it down.
 
 ### Load Balancer and Autoscaling Group
 
@@ -132,7 +136,12 @@ ansible-playbook -e "aws_region=us-east-1" -e "web_app_release_version=VERSION" 
 
 Similarly to above, substitute `VERSION` with the actual version.
 
+Optionally, when `-e "pause_after_instance_ready=true"` flag is specified, the playbook will pause after the web app
+candidate instance is ready, before taking its AMI and shutting it down.
+
 ## SSH to Bastion and beyond
+
+Prerequiesite: `ssh-agent` must be running on local machine and it must have the keys added to it via `ssh-add`.
 
 External SSH sessions can only be established to the bastion host. Get the IP address of the bastion host from the AWS console, and then
 

--- a/create_base_ami.yml
+++ b/create_base_ami.yml
@@ -10,7 +10,7 @@
     - {
         role: aws-ami-lookup,
         owner_account_id: 679593333241, # Canonical
-        filter_by_name: "ubuntu-minimal/images/hvm-ssd/ubuntu-focal-20.04-amd64-minimal-*"
+        filter_by_name: "ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-*"
       }
     - {
         role: aws-ec2,

--- a/create_web_app_ami.yml
+++ b/create_web_app_ami.yml
@@ -28,8 +28,17 @@
   roles:
     - {
         role: web-app-release,
-        app_version: "{{ web_app_release_version }}"
+        app_version: "{{ web_app_release_version }}",
+        os_arch: "ubuntu-22.04-amd64"
       }
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Pause to verify web app candidate instance
+      pause:
+        prompt: "Web App candidate instance is ready. Press enter when ready to proceed."
+      when: pause_after_instance_ready | default('false') == 'true'
 
 - hosts: localhost
   roles:

--- a/provision_bastion.yml
+++ b/provision_bastion.yml
@@ -17,6 +17,7 @@
         instance_tags: {"Name": "bastion"},
         instance_type: "t3.nano",
         count: 1,
+        count_filters: {"tag:Name": "bastion", "instance-state-name": "running"},
         vpc_subnet_id: "{{ aws_vpc_output.stack_outputs.PublicSubnetDId }}",
         security_group_id: "{{ aws_vpc_sg_output.stack_outputs.BastionSgId }}",
         region: "{{ aws_region }}"

--- a/roles/web-app-release/tasks/main.yml
+++ b/roles/web-app-release/tasks/main.yml
@@ -3,11 +3,12 @@
 # Installs given version of the OTP application as a systemd service
 # Inputs:
 # - app_version
+# - os_arch
 # Outputs: None
 
 - name: Download release archive
   get_url:
-    url: "https://github.com/RinseOne/rinseweb/releases/download/{{ app_version }}/rinseweb.tar.gz"
+    url: "https://github.com/RinseOne/rinseweb/releases/download/{{ app_version }}/rinseweb-{{ os_arch }}.tar.gz"
     dest: /tmp/rinseweb.tar.gz
 
 - name: Unarchive the release

--- a/roles/web-base/tasks/main.yml
+++ b/roles/web-base/tasks/main.yml
@@ -1,23 +1,12 @@
 ---
 
-- name: Download Erlang Solutions repo key package
-  get_url:
-    url: https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb
-    dest: /tmp/erlang-solutions_2.0_all.deb
-
-- name: Install Erlang Solutions repo key
-  become: yes
-  apt:
-    deb: /tmp/erlang-solutions_2.0_all.deb
-
 - name: Update apt cache
   become: yes
   apt:
     update_cache: yes
 
-- name: Install erlang and units
+- name: Install units
   become: yes
   apt:
     pkg:
-    - erlang
     - units


### PR DESCRIPTION
## Description

Upgrade all from Ubuntu 20.04 to 22.04.

Changes:

* Start using Ubuntu 22.04 AMI everywhere
* Use the new release URL for rinseweb that now includes OS and arch in filename (RinseOne/rinseweb#43)
* Remove unnecessary install of erlang in `web-base` role
* Add an option to pause playbook (default false) after web app candidate instance is ready